### PR TITLE
Fixed the version requirement for thecodingmachine/safe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "illuminate/console": "^8 || ^9",
     "illuminate/contracts": "^8 || ^9",
     "illuminate/support": "^8 || ^9",
-    "thecodingmachine/safe": "^1 || ^1"
+    "thecodingmachine/safe": "^1 || ^2"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2",


### PR DESCRIPTION
Looks like there was a mistake made by defining v1 twice as a version requirement in composer.